### PR TITLE
fix(pr): allow protected branches when current equals target

### DIFF
--- a/.claude/commands/PRD-cycle/prd-new.md
+++ b/.claude/commands/PRD-cycle/prd-new.md
@@ -1,5 +1,6 @@
 ---
 allowed-tools: Bash(date -u +"%Y-%m-%dT%H:%M:%SZ"), Read, Write, LS
+model: claude-opus-4-1
 ---
 
 # PRD New

--- a/.claude/commands/SDD-cycle/analyze.md
+++ b/.claude/commands/SDD-cycle/analyze.md
@@ -1,5 +1,6 @@
 ---
 description: Perform a non-destructive cross-artifact consistency and quality analysis across spec.md, plan.md, and tasks.md after task generation.
+model: claude-opus-4-1
 ---
 
 The user input to you can be provided directly by the agent or as a command argument - you **MUST** consider it before proceeding with the prompt (if not empty).

--- a/.claude/commands/SDD-cycle/clarify.md
+++ b/.claude/commands/SDD-cycle/clarify.md
@@ -1,5 +1,6 @@
 ---
 description: Identify underspecified areas in the current feature spec by asking up to 5 highly targeted clarification questions and encoding answers back into the spec.
+model: claude-opus-4-1
 ---
 
 The user input to you can be provided directly by the agent or as a command argument - you **MUST** consider it before proceeding with the prompt (if not empty).

--- a/.claude/commands/SDD-cycle/constitution.md
+++ b/.claude/commands/SDD-cycle/constitution.md
@@ -1,5 +1,6 @@
 ---
 description: Create or update the project constitution from interactive or provided principle inputs, ensuring all dependent templates stay in sync.
+model: claude-opus-4-1-20250805
 ---
 
 The user input to you can be provided directly by the agent or as a command argument - you **MUST** consider it before proceeding with the prompt (if not empty).
@@ -14,16 +15,16 @@ Follow this execution flow:
 
 1. Load the existing constitution template at `.specify/memory/constitution.md`.
    - Identify every placeholder token of the form `[ALL_CAPS_IDENTIFIER]`.
-   **IMPORTANT**: The user might require less or more principles than the ones used in the template. If a number is specified, respect that - follow the general template. You will update the doc accordingly.
+     **IMPORTANT**: The user might require less or more principles than the ones used in the template. If a number is specified, respect that - follow the general template. You will update the doc accordingly.
 
 2. Collect/derive values for placeholders:
    - If user input (conversation) supplies a value, use it.
    - Otherwise infer from existing repo context (README, docs, prior constitution versions if embedded).
    - For governance dates: `RATIFICATION_DATE` is the original adoption date (if unknown ask or mark TODO), `LAST_AMENDED_DATE` is today if changes are made, otherwise keep previous.
    - `CONSTITUTION_VERSION` must increment according to semantic versioning rules:
-     * MAJOR: Backward incompatible governance/principle removals or redefinitions.
-     * MINOR: New principle/section added or materially expanded guidance.
-     * PATCH: Clarifications, wording, typo fixes, non-semantic refinements.
+     - MAJOR: Backward incompatible governance/principle removals or redefinitions.
+     - MINOR: New principle/section added or materially expanded guidance.
+     - PATCH: Clarifications, wording, typo fixes, non-semantic refinements.
    - If version bump type ambiguous, propose reasoning before finalizing.
 
 3. Draft the updated constitution content:
@@ -61,6 +62,7 @@ Follow this execution flow:
    - Suggested commit message (e.g., `docs: amend constitution to vX.Y.Z (principle additions + governance update)`).
 
 Formatting & Style Requirements:
+
 - Use Markdown headings exactly as in the template (do not demote/promote levels).
 - Wrap long rationale lines to keep readability (<100 chars ideally) but do not hard enforce with awkward breaks.
 - Keep a single blank line between sections.

--- a/.claude/commands/SDD-cycle/plan.md
+++ b/.claude/commands/SDD-cycle/plan.md
@@ -1,5 +1,6 @@
 ---
 description: Execute the implementation planning workflow using the plan template to generate design artifacts.
+model: claude-opus-4-1
 ---
 
 The user input to you can be provided directly by the agent or as a command argument - you **MUST** consider it before proceeding with the prompt (if not empty).

--- a/.claude/commands/git-github/pr.md
+++ b/.claude/commands/git-github/pr.md
@@ -40,8 +40,16 @@ Crea PR usando branch actual hacia el target branch especificado.
 - Validar que rama actual no sea igual al target:
   ```bash
   if [[ "$current_branch" == "$target_branch" ]]; then
-      echo "❌ Error: No puedes crear un PR de una rama hacia sí misma"
-      exit 1
+      # Excepción: permitir si es rama protegida (se creará feature branch automáticamente)
+      PROTECTED_BRANCHES="^(main|master|develop|dev|staging|production|prod|qa|release/.+|hotfix/.+)$"
+      if [[ "$current_branch" =~ $PROTECTED_BRANCHES ]]; then
+          echo "⚠️ Rama protegida detectada: $current_branch (igual a target: $target_branch)"
+          echo "📍 Se creará una feature branch automáticamente en el siguiente paso..."
+      else
+          echo "❌ Error: No puedes crear un PR de una rama hacia sí misma"
+          echo "   (current: $current_branch, target: $target_branch)"
+          exit 1
+      fi
   fi
   ```
 - Verificar divergencia:


### PR DESCRIPTION
## Summary

Mejora en la validación de ramas protegidas para permitir la creación de PRs cuando la rama actual es igual al target branch. Se optimizan modelos estratégicos en workflows SDD/PRD.

## Changes Made (2 commits)

- `e0beb0c` fix(pr): allow protected branches when current equals target
- `a72e43d` feat(commands): strategic model optimization across SDD/PRD workflows

## Files & Impact

- **Files modified**: 6
- **Lines**: +20 -6
- **Areas affected**: .claude/commands/PRD-cycle, .claude/commands/SDD-cycle, .claude/commands/git-github

## Test Plan

**Bug Fix Verification:**
- [ ] Verificar que se permite crear PR cuando `current_branch == target_branch` en ramas protegidas
- [ ] Validar que se crea feature branch automáticamente con nombre correcto
- [ ] Confirmar que otras validaciones de rama siguen funcionando correctamente

**Configuration Changes:**
- [ ] Verificar que los modelos optimizados (claude-opus-4-1) se aplican correctamente en comandos SDD/PRD
- [ ] Validar que no hay regresiones en flujos de constitución y clarificación

**Integration:**
- [ ] Ejecutar `/pr main` desde rama protegida y verificar flujo completo
- [ ] Validar que security review se ejecuta antes de crear PR
- [ ] Confirmar que el logging de operaciones funciona correctamente

## Breaking Changes

None