### PR TITLE
fix(workflow): add contents write permission for gh-pages deploy

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -8,6 +8,8 @@ on:
 jobs:
   deploy:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     steps:
       - uses: actions/checkout@v4
 


### PR DESCRIPTION
## Problem

GitHub Actions workflow failing with:
```
remote: Permission to Trivance-io/trivance-ai-orchestrator.git denied to github-actions[bot].
fatal: unable to access 'https://github.com/Trivance-io/trivance-ai-orchestrator.git/': The requested URL returned error: 403
```

## Solution

Add `permissions: contents: write` to deploy job.

Required for `peaceiris/actions-gh-pages@v4` to push to `gh-pages` branch.

## Changes

- 2 lines added to `.github/workflows/deploy.yml`

## Impact

Unblocks GitHub Pages deployment.