### PR TITLE
fix(docs): configure VitePress handbook for GitHub Pages deployment

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -4,12 +4,20 @@ on:
   push:
     branches: [main]
     paths: ["human-handbook/**"]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: "pages"
+  cancel-in-progress: false
 
 jobs:
-  deploy:
+  build:
     runs-on: ubuntu-latest
-    permissions:
-      contents: write
     steps:
       - uses: actions/checkout@v4
 
@@ -21,7 +29,16 @@ jobs:
       - run: npm ci
       - run: npm run docs:build
 
-      - uses: peaceiris/actions-gh-pages@v4
+      - uses: actions/upload-pages-artifact@v3
         with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          publish_dir: ./human-handbook/.vitepress/dist
+          path: ./human-handbook/.vitepress/dist
+
+  deploy:
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - id: deployment
+        uses: actions/deploy-pages@v4

--- a/human-handbook/.vitepress/config.js
+++ b/human-handbook/.vitepress/config.js
@@ -4,6 +4,7 @@ export default defineConfig({
   lang: "es-ES",
   title: "Trivance AI Handbook",
   description: "Guía completa para desarrollo AI-first con Claude Code",
+  base: "/trivance-ai-orchestrator/",
   appearance: true,
 
   themeConfig: {


### PR DESCRIPTION
## Summary

Fixes GitHub Pages deployment for VitePress documentation site by adding base path configuration, migrating to official GitHub Actions deployment method, and disabling Jekyll processing.

**Root Cause**: The deployed site at https://trivance-io.github.io/trivance-ai-orchestrator/ was showing incorrect content (README.md) instead of the VitePress handbook due to missing base path configuration and incorrect workflow setup.

**Solution**: Configure VitePress for subdirectory deployment and use GitHub's official Pages deployment actions.

## Changes Made (1 commit)

- **1a4fabb** fix: configure VitePress handbook for GitHub Pages deployment

## Files & Impact

- **Files modified**: 3
- **Lines**: +24 -6 (18 net)
- **Areas affected**:
  - `.github/workflows/` - CI/CD deployment automation
  - `human-handbook/.vitepress/` - VitePress configuration
  - `human-handbook/public/` - Static assets

**Key changes:**
1. **VitePress config** (`human-handbook/.vitepress/config.js`):
   - Added `base: "/trivance-ai-orchestrator/"` for correct asset/navigation URLs

2. **GitHub Actions workflow** (`.github/workflows/deploy.yml`):
   - Migrated from `peaceiris/actions-gh-pages@v4` to official `actions/deploy-pages@v4`
   - Updated permissions: `contents: read`, `pages: write`, `id-token: write`
   - Separated build and deploy jobs for better isolation
   - Added `workflow_dispatch` for manual triggers
   - Added concurrency control

3. **Jekyll disable** (`human-handbook/public/.nojekyll`):
   - Created marker file to prevent Jekyll from ignoring `.vitepress` directory

## Technical Details

**Before** (Broken):
- Asset URLs: `/assets/style.css` → 404 on GitHub Pages
- Navigation: `/docs/quickstart.html` → 404
- Workflow permissions insufficient (403 errors)
- Using third-party deployment action

**After** (Fixed):
- Asset URLs: `/trivance-ai-orchestrator/assets/style.css` ✅
- Navigation: `/trivance-ai-orchestrator/docs/quickstart.html` ✅
- Official GitHub Actions with correct permissions ✅
- Jekyll disabled to prevent directory exclusions ✅

## Security Review

✅ **PASSED** - Security review completed with 0 blocking findings (confidence: 0.95)

**Security improvements**:
- Better permission model: `contents: read` instead of `contents: write`
- Official GitHub actions instead of third-party
- Environment isolation: `github-pages` environment
- Reproducible builds: `npm ci` maintained

## Test Plan

- [x] Local build successful (`npm run docs:build` - 3.62s)
- [x] Asset URLs verified with `/trivance-ai-orchestrator/` prefix
- [x] `.nojekyll` present in build output
- [x] Workflow syntax validated
- [ ] **Post-merge**: Configure GitHub Pages Settings to use "GitHub Actions" source
- [ ] Monitor workflow execution (2-3 min)
- [ ] Verify site at https://trivance-io.github.io/trivance-ai-orchestrator/
- [ ] Validate all pages accessible (homepage + 6 docs)
- [ ] Check no 404 errors in browser console

## Breaking Changes

None

## Post-Merge Steps

**CRITICAL - Manual configuration required (one-time):**

1. Go to: `Settings → Pages` in GitHub repository
2. Under "Build and deployment":
   - **Source**: Change from "Deploy from a branch" to **"GitHub Actions"**
3. Save changes
4. Wait for automatic deployment (~2-3 minutes)

**Verification**:
```bash
gh api repos/Trivance-io/trivance-ai-orchestrator/pages | jq '.build_type'
# Should return: "workflow" (not "legacy")
```

Site will be live at: https://trivance-io.github.io/trivance-ai-orchestrator/

Subsequent deployments are fully automatic on push to main.